### PR TITLE
Add hybrid TLS routing with SNI passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ domains:
           - location: /
             upgrade: false
             target: https://192.168.0.6:8443
+
+# Optional raw TLS passthrough routes. These share :443 with Routy's
+# normal managed HTTPS routes. Routy reads the TLS SNI hostname and
+# proxies the encrypted stream without terminating TLS.
+tlsRoutes:
+  - host: vault.example.com
+    target: 10.0.0.20:443
+  - host: mqtt.example.com
+    target: tls://10.0.0.30:8883
 ```
 
 ### Deny List

--- a/cfg.yaml.dist
+++ b/cfg.yaml.dist
@@ -33,3 +33,12 @@ domains:
           - location: /
             upgrade: false
             target: https://192.168.0.6:8443
+
+# Optional raw TLS passthrough routes. Routy reads SNI and proxies the
+# encrypted stream without terminating TLS. These routes share :443 with
+# the managed HTTPS reverse proxy.
+tlsRoutes:
+  - host: vault.example.com
+    target: 10.0.0.20:443
+  - host: mqtt.example.com
+    target: tls://10.0.0.30:8883

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oorrwullie/routy
 
-go 1.26.0
+go 1.24.0
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oorrwullie/routy
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/internal/handlers/router.go
+++ b/internal/handlers/router.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 
 	"github.com/oorrwullie/routy/internal/logging"
@@ -64,23 +65,82 @@ func NewRouty() (*Routy, error) {
 // Route starts the routing process
 func (r *Routy) Route() error {
 	router := mux.NewRouter()
-
 	g, _ := errgroup.WithContext(context.Background())
 
-	for _, d := range r.routes.Domains {
-		if len(d.Paths) != 0 {
-			r.hostnames = append(r.hostnames, d.Name)
-		}
-		for _, sd := range d.Subdomains {
-			r.hostnames = append(r.hostnames, fmt.Sprintf("%s.%s", sd.Name, d.Name))
-		}
-	}
+	r.collectHostnames()
 
 	certManager, err := r.getCertManager()
 	if err != nil {
 		return err
 	}
 
+	r.registerHTTPRoutes(router)
+
+	// Listen for plain HTTP traffic and redirect/challenge through autocert.
+	g.Go(func() error {
+		httpServer := &http.Server{
+			Addr:    ":http",
+			Handler: certManager.HTTPHandler(nil),
+		}
+
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			r.EventLog <- logging.EventLogMessage{
+				Level:   "ERROR",
+				Caller:  "Route()->httpServer.ListenAndServe()",
+				Message: fmt.Sprintf("failed to start http server: %v", err),
+			}
+			return err
+		}
+		return nil
+	})
+
+	tcpListener, err := net.Listen("tcp", ":https")
+	if err != nil {
+		return err
+	}
+
+	tlsListener := newHybridTLSListener(tcpListener, r)
+
+	server := &http.Server{
+		Handler:   router,
+		TLSConfig: certManager.TLSConfig(),
+	}
+
+	// ServeTLS receives only the connections that are not selected for raw TLS
+	// passthrough by the hybrid listener.
+	g.Go(func() error {
+		return server.ServeTLS(tlsListener, "", "")
+	})
+
+	return g.Wait()
+}
+
+func (r *Routy) collectHostnames() {
+	r.hostnames = nil
+	seen := make(map[string]struct{})
+
+	for _, d := range r.routes.Domains {
+		if len(d.Paths) != 0 {
+			appendHostname(&r.hostnames, seen, d.Name)
+		}
+		for _, sd := range d.Subdomains {
+			appendHostname(&r.hostnames, seen, fmt.Sprintf("%s.%s", sd.Name, d.Name))
+		}
+	}
+}
+
+func appendHostname(hostnames *[]string, seen map[string]struct{}, hostname string) {
+	if hostname == "" {
+		return
+	}
+	if _, ok := seen[hostname]; ok {
+		return
+	}
+	seen[hostname] = struct{}{}
+	*hostnames = append(*hostnames, hostname)
+}
+
+func (r *Routy) registerHTTPRoutes(router *mux.Router) {
 	for _, domain := range r.routes.Domains {
 		if len(domain.Paths) != 0 {
 			sd := models.Subdomain{
@@ -92,45 +152,13 @@ func (r *Routy) Route() error {
 		}
 
 		for _, sd := range domain.Subdomains {
-			if len(sd.Paths) != 0 {
-				for _, path := range sd.Paths {
-					if path.Upgrade {
-						go r.handleWebSocket(path)
-					} else {
-						go r.handleHttp(router, domain, sd, path)
-					}
+			for _, path := range sd.Paths {
+				if path.Upgrade {
+					go r.handleWebSocket(path)
+				} else {
+					r.handleHttp(router, domain, sd, path)
 				}
 			}
 		}
-
-		// listens fo any traffic on http and redirects it to https
-		go func() {
-			httpServer := &http.Server{
-				Addr:    ":http",
-				Handler: certManager.HTTPHandler(nil),
-			}
-
-			if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				r.EventLog <- logging.EventLogMessage{
-					Level:   "ERROR",
-					Caller:  "Route()->httpServer.ListenAndServe()",
-					Message: fmt.Sprintf("failed to start http server: %v", err),
-				}
-			}
-		}()
-
-		server := &http.Server{
-			Addr:      ":https",
-			Handler:   router,
-			TLSConfig: certManager.TLSConfig(),
-		}
-
-		// start the https server
-		g.Go(func() error {
-			return server.ListenAndServeTLS("", "")
-		})
-
 	}
-
-	return g.Wait()
 }

--- a/internal/handlers/tlsPassthrough.go
+++ b/internal/handlers/tlsPassthrough.go
@@ -1,0 +1,267 @@
+package handlers
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/oorrwullie/routy/internal/logging"
+)
+
+const maxTLSClientHelloSize = 64 * 1024
+
+type bufferedConn struct {
+	net.Conn
+	reader *bufio.Reader
+}
+
+func (c *bufferedConn) Read(p []byte) (int, error) {
+	if c.reader != nil && c.reader.Buffered() > 0 {
+		return c.reader.Read(p)
+	}
+	return c.Conn.Read(p)
+}
+
+type hybridTLSListener struct {
+	net.Listener
+	routy             *Routy
+	passthroughRoutes map[string]string
+}
+
+func (l *hybridTLSListener) Accept() (net.Conn, error) {
+	for {
+		conn, err := l.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+
+		reader := bufio.NewReader(conn)
+		sni, err := peekClientHelloSNI(reader)
+		if err != nil {
+			l.routy.EventLog <- logging.EventLogMessage{
+				Level:   "WARN",
+				Caller:  "hybridTLSListener.Accept()->peekClientHelloSNI()",
+				Message: fmt.Sprintf("could not read TLS SNI from %s: %v", conn.RemoteAddr(), err),
+			}
+			return &bufferedConn{Conn: conn, reader: reader}, nil
+		}
+
+		if target, ok := l.passthroughRoutes[strings.ToLower(sni)]; ok {
+			go l.routy.proxyTLS(&bufferedConn{Conn: conn, reader: reader}, sni, target)
+			continue
+		}
+
+		return &bufferedConn{Conn: conn, reader: reader}, nil
+	}
+}
+
+func (r *Routy) getPassthroughRouteMap() map[string]string {
+	routes := make(map[string]string)
+	if r.routes == nil {
+		return routes
+	}
+
+	for _, route := range r.routes.TLSRoutes {
+		host := strings.ToLower(strings.TrimSpace(route.Host))
+		target := strings.TrimSpace(route.Target)
+		if host == "" || target == "" {
+			continue
+		}
+		routes[host] = normalizeTCPAddress(target, "443")
+	}
+
+	return routes
+}
+
+func (r *Routy) proxyTLS(client net.Conn, sni, target string) {
+	defer func() {
+		_ = client.Close()
+	}()
+
+	if r.denyList.IsDenied(ipAddrFromNetAddr(client.RemoteAddr())) {
+		return
+	}
+
+	backend, err := net.DialTimeout("tcp", target, 10*time.Second)
+	if err != nil {
+		r.EventLog <- logging.EventLogMessage{
+			Level:   "ERROR",
+			Caller:  "proxyTLS()->net.DialTimeout()",
+			Message: fmt.Sprintf("failed to connect TLS passthrough route %s -> %s: %v", sni, target, err),
+		}
+		return
+	}
+	defer func() {
+		_ = backend.Close()
+	}()
+
+	r.EventLog <- logging.EventLogMessage{
+		Level:   "INFO",
+		Caller:  "proxyTLS()",
+		Message: fmt.Sprintf("TLS passthrough %s -> %s", sni, target),
+	}
+
+	done := make(chan struct{}, 2)
+	go copyAndClose(backend, client, done)
+	go copyAndClose(client, backend, done)
+	<-done
+}
+
+func copyAndClose(dst net.Conn, src net.Conn, done chan<- struct{}) {
+	_, _ = io.Copy(dst, src)
+	_ = dst.Close()
+	_ = src.Close()
+	done <- struct{}{}
+}
+
+func ipAddrFromNetAddr(addr net.Addr) string {
+	if addr == nil {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return addr.String()
+	}
+	return host
+}
+
+func normalizeTCPAddress(address, defaultPort string) string {
+	address = strings.TrimSpace(address)
+	address = strings.TrimPrefix(address, "tls://")
+	address = strings.TrimPrefix(address, "tcp://")
+
+	if _, _, err := net.SplitHostPort(address); err == nil {
+		return address
+	}
+	return net.JoinHostPort(address, defaultPort)
+}
+
+func peekClientHelloSNI(reader *bufio.Reader) (string, error) {
+	header, err := reader.Peek(5)
+	if err != nil {
+		return "", err
+	}
+	if header[0] != 0x16 {
+		return "", fmt.Errorf("not a TLS handshake record")
+	}
+
+	recordLen := int(binary.BigEndian.Uint16(header[3:5]))
+	if recordLen <= 0 || recordLen > maxTLSClientHelloSize {
+		return "", fmt.Errorf("invalid TLS record length %d", recordLen)
+	}
+
+	data, err := reader.Peek(5 + recordLen)
+	if err != nil {
+		return "", err
+	}
+
+	return parseClientHelloSNI(data[5:])
+}
+
+func parseClientHelloSNI(handshake []byte) (string, error) {
+	if len(handshake) < 4 || handshake[0] != 0x01 {
+		return "", fmt.Errorf("not a ClientHello")
+	}
+
+	handshakeLen := int(handshake[1])<<16 | int(handshake[2])<<8 | int(handshake[3])
+	if handshakeLen+4 > len(handshake) {
+		return "", fmt.Errorf("incomplete ClientHello")
+	}
+
+	body := handshake[4 : 4+handshakeLen]
+	if len(body) < 34 {
+		return "", fmt.Errorf("ClientHello too short")
+	}
+
+	pos := 34 // protocol version + random
+	if pos >= len(body) {
+		return "", fmt.Errorf("missing session id")
+	}
+	sessionIDLen := int(body[pos])
+	pos++
+	pos += sessionIDLen
+	if pos+2 > len(body) {
+		return "", fmt.Errorf("missing cipher suites")
+	}
+
+	cipherSuitesLen := int(binary.BigEndian.Uint16(body[pos : pos+2]))
+	pos += 2 + cipherSuitesLen
+	if pos >= len(body) {
+		return "", fmt.Errorf("missing compression methods")
+	}
+
+	compressionMethodsLen := int(body[pos])
+	pos++
+	pos += compressionMethodsLen
+	if pos+2 > len(body) {
+		return "", fmt.Errorf("missing extensions")
+	}
+
+	extensionsLen := int(binary.BigEndian.Uint16(body[pos : pos+2]))
+	pos += 2
+	if pos+extensionsLen > len(body) {
+		return "", fmt.Errorf("incomplete extensions")
+	}
+
+	extensions := body[pos : pos+extensionsLen]
+	for len(extensions) >= 4 {
+		extensionType := binary.BigEndian.Uint16(extensions[0:2])
+		extensionLen := int(binary.BigEndian.Uint16(extensions[2:4]))
+		extensions = extensions[4:]
+		if extensionLen > len(extensions) {
+			return "", fmt.Errorf("incomplete extension")
+		}
+
+		if extensionType == 0x0000 {
+			return parseServerNameExtension(extensions[:extensionLen])
+		}
+
+		extensions = extensions[extensionLen:]
+	}
+
+	return "", fmt.Errorf("SNI not found")
+}
+
+func parseServerNameExtension(data []byte) (string, error) {
+	if len(data) < 2 {
+		return "", fmt.Errorf("server name extension too short")
+	}
+
+	listLen := int(binary.BigEndian.Uint16(data[0:2]))
+	data = data[2:]
+	if listLen > len(data) {
+		return "", fmt.Errorf("server name list incomplete")
+	}
+	data = data[:listLen]
+
+	for len(data) >= 3 {
+		nameType := data[0]
+		nameLen := int(binary.BigEndian.Uint16(data[1:3]))
+		data = data[3:]
+		if nameLen > len(data) {
+			return "", fmt.Errorf("server name incomplete")
+		}
+		if nameType == 0 {
+			serverName := strings.ToLower(string(data[:nameLen]))
+			if serverName == "" {
+				return "", fmt.Errorf("empty server name")
+			}
+			return serverName, nil
+		}
+		data = data[nameLen:]
+	}
+
+	return "", fmt.Errorf("host_name SNI not found")
+}
+
+func newHybridTLSListener(listener net.Listener, routy *Routy) net.Listener {
+	return &hybridTLSListener{
+		Listener:          listener,
+		routy:             routy,
+		passthroughRoutes: routy.getPassthroughRouteMap(),
+	}
+}

--- a/internal/handlers/tlsPassthrough_test.go
+++ b/internal/handlers/tlsPassthrough_test.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestParseClientHelloSNI(t *testing.T) {
+	t.Parallel()
+
+	serverName := "vault.example.com"
+	clientHello, err := tlsClientHelloBytes(serverName)
+	if err != nil {
+		t.Fatalf("build ClientHello: %v", err)
+	}
+
+	got, err := peekClientHelloSNI(bufio.NewReader(bytes.NewReader(clientHello)))
+	if err != nil {
+		t.Fatalf("peekClientHelloSNI returned error: %v", err)
+	}
+	if got != serverName {
+		t.Fatalf("SNI = %q, want %q", got, serverName)
+	}
+}
+
+func TestNormalizeTCPAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "10.0.0.20", want: "10.0.0.20:443"},
+		{in: "10.0.0.20:8443", want: "10.0.0.20:8443"},
+		{in: "tls://vault.internal:443", want: "vault.internal:443"},
+		{in: "tcp://vault.internal:8443", want: "vault.internal:8443"},
+	}
+
+	for _, tt := range tests {
+		if got := normalizeTCPAddress(tt.in, "443"); got != tt.want {
+			t.Fatalf("normalizeTCPAddress(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func tlsClientHelloBytes(serverName string) ([]byte, error) {
+	clientConn, serverConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+	defer func() { _ = serverConn.Close() }()
+
+	errCh := make(chan error, 1)
+	go func() {
+		conn := tls.Client(clientConn, &tls.Config{ServerName: serverName, InsecureSkipVerify: true})
+		errCh <- conn.Handshake()
+	}()
+
+	buf := make([]byte, maxTLSClientHelloSize)
+	_ = serverConn.SetReadDeadline(time.Now().Add(time.Second))
+	n, err := serverConn.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	_ = serverConn.Close()
+	<-errCh
+	return buf[:n], nil
+}

--- a/internal/models/domainRoutes.go
+++ b/internal/models/domainRoutes.go
@@ -8,7 +8,8 @@ const configFilename string = "cfg.yaml"
 
 type (
 	Routes struct {
-		Domains []Domain `yaml:"domains"`
+		Domains   []Domain   `yaml:"domains"`
+		TLSRoutes []TLSRoute `yaml:"tlsRoutes,omitempty"`
 	}
 
 	Domain struct {
@@ -24,12 +25,12 @@ type (
 	}
 
 	CORSConfig struct {
-		AllowOrigins    []string `yaml:"allowOrigins,omitempty"`
-		AllowMethods    []string `yaml:"allowMethods,omitempty"`
-		AllowHeaders    []string `yaml:"allowHeaders,omitempty"`
-		ExposeHeaders   []string `yaml:"exposeHeaders,omitempty"`
+		AllowOrigins     []string `yaml:"allowOrigins,omitempty"`
+		AllowMethods     []string `yaml:"allowMethods,omitempty"`
+		AllowHeaders     []string `yaml:"allowHeaders,omitempty"`
+		ExposeHeaders    []string `yaml:"exposeHeaders,omitempty"`
 		AllowCredentials bool     `yaml:"allowCredentials,omitempty"`
-		MaxAge          int      `yaml:"maxAge,omitempty"`
+		MaxAge           int      `yaml:"maxAge,omitempty"`
 	}
 
 	Path struct {
@@ -37,6 +38,14 @@ type (
 		Upgrade    bool   `yaml:"upgrade"`
 		Target     string `yaml:"target"`
 		ListenPort int    `yaml:"listenPort,omitempty"`
+	}
+
+	// TLSRoute is a raw TLS passthrough route. Routy reads the SNI from the
+	// ClientHello and proxies the encrypted TCP stream to Target without
+	// terminating TLS.
+	TLSRoute struct {
+		Host   string `yaml:"host"`
+		Target string `yaml:"target"`
 	}
 )
 


### PR DESCRIPTION
# Add hybrid TLS routing with SNI passthrough

## Summary

This PR introduces hybrid TLS routing, allowing Routy to support both traditional HTTPS reverse proxying and end-to-end TLS passthrough from the same :443 listener.

By inspecting the TLS ClientHello and routing based on SNI, Routy can now automatically determine whether to terminate TLS or transparently proxy the encrypted connection to a backend.

This preserves Routy’s philosophy of being simple by default while enabling advanced routing scenarios with minimal configuration.

## What’s Included

* Added support for tlsRoutes configuration
* Implemented SNI parsing from the TLS ClientHello
* Added raw TCP proxying for TLS passthrough routes
* Introduced a hybrid TLS listener that supports:
    * HTTPS termination (existing behavior)
    * TLS passthrough (new behavior)
* Refactored listener initialization so HTTP and HTTPS listeners are only started once
* Added TCP target normalization
* Added tests for SNI parsing and address normalization
* Updated configuration examples and documentation

```yaml
routes:
  - host: app.example.com
    target: http://10.0.0.10:8080

tlsRoutes:
  - host: vault.example.com
    target: 10.0.0.20:443
```

### In this configuration:

* app.example.com is handled by Routy using automatic HTTPS and reverse proxying.
* vault.example.com is transparently proxied to the backend without terminating TLS.

Both services are accessible through the same public :443 listener.

### Why

Many reverse proxies require users to choose between:

* TLS termination
* TLS passthrough